### PR TITLE
Handle TMX search criteria generically, support custom per-series search criteria

### DIFF
--- a/worlds/trackmania/__init__.py
+++ b/worlds/trackmania/__init__.py
@@ -109,7 +109,6 @@ class TrackmaniaWorld(World):
                              "MapCount": map_count,
                              "SearchCriteria": search_criteria}
             self.series_data.append(values)
-            print(values)
 
     def fill_slot_data(self) -> dict:
         return {

--- a/worlds/trackmania/__init__.py
+++ b/worlds/trackmania/__init__.py
@@ -52,11 +52,9 @@ class TrackmaniaWorld(World):
 
     item_name_groups = trackmania_item_groups
 
-    series_data: list
-
     def __init__(self, multiworld: "MultiWorld", player: int):
         super().__init__(multiworld, player)
-        self.series_data = []
+        self.series_data: list = []
 
     def create_item(self, name: str) -> Item:
         return create_item(self, name)

--- a/worlds/trackmania/__init__.py
+++ b/worlds/trackmania/__init__.py
@@ -71,6 +71,7 @@ class TrackmaniaWorld(World):
 
     def generate_early(self):
         medal_percent: float = float(self.options.medal_requirement.value) / 100.0
+        base_search_criteria: dict = self.options.custom_series.value.get("all", {})
 
         for series in range(1, self.options.series_number.value + 1):
             map_count: int = random.randint(self.options.series_minimum_map_number.value,
@@ -81,7 +82,8 @@ class TrackmaniaWorld(World):
             medals: int = round(map_count * medal_percent)
             medals = max(1, min(medals, map_count))  # clamp between 1 and map_count
 
-            search_criteria: dict = self.options.custom_series.value.get(series, {}).copy()
+            search_criteria: dict = base_search_criteria.copy()
+            search_criteria.update(self.options.custom_series.value.get(series, {}))
 
             # Fill in global defaults and settings
             if "map_tags" not in search_criteria:

--- a/worlds/trackmania/__init__.py
+++ b/worlds/trackmania/__init__.py
@@ -52,9 +52,11 @@ class TrackmaniaWorld(World):
 
     item_name_groups = trackmania_item_groups
 
+    series_data: list
+
     def __init__(self, multiworld: "MultiWorld", player: int):
         super().__init__(multiworld, player)
-        self.slot_data: dict = {}
+        self.series_data = []
 
     def create_item(self, name: str) -> Item:
         return create_item(self, name)
@@ -70,38 +72,51 @@ class TrackmaniaWorld(World):
         set_rules(self)
 
     def generate_early(self):
-        series_data: list = []
         medal_percent: float = float(self.options.medal_requirement.value) / 100.0
-        for x in range(self.options.series_number):
+
+        for series in range(1, self.options.series_number.value + 1):
             map_count: int = random.randint(self.options.series_minimum_map_number.value,
                                             self.options.series_maximum_map_number.value)
-            if x == 0 and self.options.first_series_size.value > 0:
+            if series == 1 and self.options.first_series_size.value > 0:
                 map_count = self.options.first_series_size.value
 
             medals: int = round(map_count * medal_percent)
             medals = max(1, min(medals, map_count))  # clamp between 1 and map_count
 
-            tags: list = list(self.options.map_tags.value)
-            if self.options.random_series_tags > 0 and len(tags) > 0:
-                tag = random.choice(tags)
-                tags = [tag]
+            search_criteria: dict = self.options.custom_series.value.get(series, {}).copy()
+
+            # Fill in global defaults and settings
+            if "map_tags" not in search_criteria:
+                tags: list = list(self.options.map_tags.value)
+                if self.options.random_series_tags > 0 and len(tags) > 1:
+                    search_criteria["map_tags"] = [random.choice(tags)]
+                else:
+                    search_criteria["map_tags"] = tags
+
+            if "map_etags" not in search_criteria:
+                search_criteria["map_etags"] = list(self.options.map_etags.value)
+
+            if "map_tags_inclusive" not in search_criteria:
+                search_criteria["map_tags_inclusive"] = self.options.map_tags_inclusive.value
+
+            if "difficulties" not in search_criteria:
+                search_criteria["difficulties"] = list(self.options.difficulties.value)
+
+            if "max_length" not in search_criteria:
+                search_criteria["max_length"] = 5*60*1000  # Enforce a default 5 minute upper limit
 
             values : dict = {"MedalTotal": medals,
                              "MapCount": map_count,
-                             "MapTags": tags}
-
-            series_data.append(values)
-
-        self.slot_data = {"TargetTimeSetting": (float(self.options.target_time.value) / 100.0),
-                           "SeriesNumber": self.options.series_number.value,
-                           "MapTagsInclusive": self.options.map_tags_inclusive.value,
-                           "MapETags": self.options.map_etags.value,
-                           "Difficulties": self.options.difficulties.value,
-                           "SeriesData": series_data}
-
+                             "SearchCriteria": search_criteria}
+            self.series_data.append(values)
+            print(values)
 
     def fill_slot_data(self) -> dict:
-        return self.slot_data
+        return {
+            "TargetTimeSetting": (float(self.options.target_time.value) / 100.0),
+            "SeriesNumber": self.options.series_number.value,
+            "SeriesData": self.series_data
+        }
 
     def get_filler_item_name(self) -> str:
         return get_filler_item_name()

--- a/worlds/trackmania/items.py
+++ b/worlds/trackmania/items.py
@@ -57,8 +57,8 @@ def create_itempool(world: "TrackmaniaWorld") -> list[Item]:
     itempool: list[Item] = []
 
     total_map_count: int = 0#world.options.series_number * world.options.series_map_number
-    for x in range(0, world.options.series_number):
-        total_map_count += world.slot_data["SeriesData"][x]["MapCount"]
+    for series in world.series_data:
+        total_map_count += series["MapCount"]
 
     #create medals for each map
     itempool += create_medals(world, "Author Medal", 300, total_map_count)

--- a/worlds/trackmania/options.py
+++ b/worlds/trackmania/options.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
+from datetime import datetime  # for custom_series: uploaded_before and uploaded_after
+from schema import Schema, And, Or, Optional  # for custom series validation
 from typing import List, Dict, Any
-from Options import Toggle, Range, OptionSet, PerGameCommonOptions, OptionGroup, ProgressionBalancing, Accessibility
+from Options import Toggle, Range, OptionSet, OptionDict, PerGameCommonOptions, OptionGroup, ProgressionBalancing, Accessibility, Visibility
 from .data import get_all_map_tags, get_excluded_map_tags, get_all_map_difficulties, get_default_map_difficulties
 
 #https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/options%20api.md
@@ -111,6 +113,78 @@ class MapDifficulties(OptionSet):
     default = get_default_map_difficulties()
 
 
+# Schema for custom series options below.
+LuaBool = Or(bool, And(int, lambda v: v in (0, 1)))
+MapIdList = And([int], lambda v: len(v) <= 100)
+TagList = And([And(str, lambda v: v in get_all_map_tags())], lambda v: len(v) <= 100)
+DifficultyList = And([And(str, lambda v: v in get_all_map_difficulties())], lambda v: len(v) <= 4)
+DateTimeString = And(str, lambda v: datetime.fromisoformat(v))
+
+class CustomSeries(OptionDict):
+    """Define custom search parameters for Trackmania Exchange for each series.
+
+    The expected format is a dictionary containing the series number you wish to customize, followed by a list of
+    options and search parameters.
+
+    The following options may be redefined on a per-series basis to override them:
+    - "map_tags"
+    - "map_etags"
+    - "map_tags_inclusive"
+    - "difficulties"
+
+    In addition, the following custom search parameters are available:
+    - "map_ids": A list of specific map IDs to randomly choose between (max 100)
+    - "name": The name of the map must contain the given string (partial search)
+    - "author": The map must be authored by the given user on TMX (by ID, not name)
+    - "map_pack": The map must be in the given map pack on TMX (by ID, not name)
+    - "uploaded_after": The map must have been uploaded after the given date
+    - "uploaded_before": The map must have been uploaded before the given date
+    - "min_length": The author time of the map must be longer than the given time, in milliseconds
+    - "max_length": The author time of the map must be shorter than the given time, in milliseconds
+    - "has_award": If true, the map must have at least 1 award
+    - "has_replay": If true, the map must have at least 1 replay
+
+    Example:
+    ```
+    custom_series:
+      1:
+        map_tags: ["LOL"]
+        difficulties: ["Beginner", "Intermediate"]
+        max_length: 20000
+        uploaded_after: "2019-12-31"
+      2:
+        map_tags: ["Tech"]
+        min_length: 40000
+        max_length: 75000
+        has_award: true
+    ```
+    """
+    display_name = "Custom Series"
+    visibility = Visibility.template|Visibility.spoiler
+    default = {}
+    schema = Schema({
+        Optional(And(int, lambda v: 1 <= v <= 10)): {
+            # Duplicates of options normally present, for overriding
+            Optional("map_tags"): TagList,
+            Optional("map_etags"): TagList,
+            Optional("map_tags_inclusive"): LuaBool,
+            Optional("difficulties"): DifficultyList,
+
+            # Advanced search parameters
+            Optional("map_ids"): MapIdList,  # API ref: `id`
+            Optional("name"): str,  # API ref: `name` - Full text search by name, partial
+            Optional("author"): int,  # API ref: `authoruserid`
+            Optional("map_pack"): int,  # API ref: `mappackid`
+            Optional("uploaded_after"): DateTimeString,  # API ref: `uploadedafter`
+            Optional("uploaded_before"): DateTimeString,  # API ref: `uploadedbefore`
+            Optional("min_length"): int,  # API ref: `authortimemin`
+            Optional("max_length"): int,  # API ref: `authortimemax`
+            Optional("has_award"): LuaBool,  # API ref: `inlatestawardedauthor`
+            Optional("has_replay"): LuaBool,  # API ref: `inhasreplay`
+        }
+    })
+
+
 @dataclass
 class TrackmaniaOptions(PerGameCommonOptions):
     progression_balancing: ProgressionBalancing
@@ -130,11 +204,14 @@ class TrackmaniaOptions(PerGameCommonOptions):
     map_etags: MapETags
     difficulties: MapDifficulties
 
+    custom_series: CustomSeries
+
 option_groups: Dict[str, List[Any]] = {
     "Generation":[ProgressionBalancing, Accessibility],
     "Difficulty":[TargetTime, SkipPercentage, MapDifficulties],
     "Campaign Configuration":[MedalRequirement, ProgressiveTargetTimeChance, SeriesNumber, SeriesMinimumMapNumber, SeriesMaximumMapNumber, RandomSeriesTags, FirstSeriesSize],
-    "Map Tags":[MapTagsInclusive, MapTags, MapETags]
+    "Map Tags":[MapTagsInclusive, MapTags, MapETags],
+    "Advanced":[CustomSeries]
 }
 
 def create_option_groups() -> List[OptionGroup]:

--- a/worlds/trackmania/options.py
+++ b/worlds/trackmania/options.py
@@ -124,7 +124,7 @@ class CustomSeries(OptionDict):
     """Define custom search parameters for Trackmania Exchange for each series.
 
     The expected format is a dictionary containing the series number you wish to customize, followed by a list of
-    options and search parameters.
+    options and search parameters. The series number may also be "all", to customize all series at once.
 
     The following options may be redefined on a per-series basis to override them:
     - "map_tags"
@@ -147,23 +147,23 @@ class CustomSeries(OptionDict):
     Example:
     ```
     custom_series:
+      all:
+        has_award: true
       1:
         map_tags: ["LOL"]
         difficulties: ["Beginner", "Intermediate"]
-        max_length: 20000
         uploaded_after: "2019-12-31"
       2:
         map_tags: ["Tech"]
         min_length: 40000
         max_length: 75000
-        has_award: true
     ```
     """
     display_name = "Custom Series"
     visibility = Visibility.template|Visibility.spoiler
     default = {}
     schema = Schema({
-        Optional(And(int, lambda v: 1 <= v <= SeriesNumber.range_end)): {
+        Optional(Or("all", And(int, lambda v: 1 <= v <= SeriesNumber.range_end))): {
             # Duplicates of options normally present, for overriding
             Optional("map_tags"): TagList,
             Optional("map_etags"): TagList,

--- a/worlds/trackmania/options.py
+++ b/worlds/trackmania/options.py
@@ -163,7 +163,7 @@ class CustomSeries(OptionDict):
     visibility = Visibility.template|Visibility.spoiler
     default = {}
     schema = Schema({
-        Optional(And(int, lambda v: 1 <= v <= 10)): {
+        Optional(And(int, lambda v: 1 <= v <= SeriesNumber.range_end)): {
             # Duplicates of options normally present, for overriding
             Optional("map_tags"): TagList,
             Optional("map_etags"): TagList,

--- a/worlds/trackmania/options.py
+++ b/worlds/trackmania/options.py
@@ -209,9 +209,8 @@ class TrackmaniaOptions(PerGameCommonOptions):
 option_groups: Dict[str, List[Any]] = {
     "Generation":[ProgressionBalancing, Accessibility],
     "Difficulty":[TargetTime, SkipPercentage, MapDifficulties],
-    "Campaign Configuration":[MedalRequirement, ProgressiveTargetTimeChance, SeriesNumber, SeriesMinimumMapNumber, SeriesMaximumMapNumber, RandomSeriesTags, FirstSeriesSize],
-    "Map Tags":[MapTagsInclusive, MapTags, MapETags],
-    "Advanced":[CustomSeries]
+    "Campaign Configuration":[MedalRequirement, ProgressiveTargetTimeChance, SeriesNumber, SeriesMinimumMapNumber, SeriesMaximumMapNumber, FirstSeriesSize],
+    "Map Search Settings":[MapTagsInclusive, RandomSeriesTags, MapTags, MapETags, CustomSeries]
 }
 
 def create_option_groups() -> List[OptionGroup]:

--- a/worlds/trackmania/regions.py
+++ b/worlds/trackmania/regions.py
@@ -45,7 +45,7 @@ def create_series_region(world: "TrackmaniaWorld", series: int) -> Region:
     reg = Region(series_name, world.player, world.multiworld)
     world.multiworld.regions.append(reg)
 
-    for x in range(world.slot_data["SeriesData"][series]["MapCount"]):
+    for x in range(world.series_data[series]["MapCount"]):
         create_track_checks(world, reg, x)
 
     return reg

--- a/worlds/trackmania/rules.py
+++ b/worlds/trackmania/rules.py
@@ -7,12 +7,12 @@ if TYPE_CHECKING:
     from . import TrackmaniaWorld
 
 def set_rules(world: "TrackmaniaWorld"):
-    medal_total: int = world.slot_data["SeriesData"][0]["MedalTotal"]
+    medal_total: int = world.series_data[0]["MedalTotal"]
     for i in range(1,world.options.series_number):
         set_series_rules(world, i, medal_total)
-        medal_total += world.slot_data["SeriesData"][i]["MedalTotal"]
+        medal_total += world.series_data[i]["MedalTotal"]
 
-    final_medal_requirement :int = medal_total
+    final_medal_requirement: int = medal_total
 
     set_rule(world.multiworld.get_entrance("Victory!", world.player),
              lambda state: state.has(get_progression_medal(world), world.player, final_medal_requirement))


### PR DESCRIPTION
Counterpart PR: SerialBoxes/ArchipelagoTrackmaniaPlugin#2

Combines all information about tags, etags, and difficulties determined from options into a "Search Criteria" dictionary, and adds that into slot data, replacing all prior tags/etags/difficulty lists that were in there before. Adds an advanced, hidden "Custom Series" option that allows fine tuning these options on a per-series basis.